### PR TITLE
Improve favorites and wishlist workflows

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,7 +14,7 @@ export default function App() {
     useEffect(() => {
         seedTeachers();
         seedCourses();
-    }, []);
+    }, [seedTeachers, seedCourses]);
 
     return (
         <NotificationProvider>

--- a/src/components/Pages/login.jsx
+++ b/src/components/Pages/login.jsx
@@ -38,7 +38,6 @@ export default function LoginModal({ open, onClose }) {
         }
 
         const savedEmail = localStorage.getItem(LS.email)?.toLowerCase();
-        const normalizedEmail = email.toLowerCase();
         const savedPassword = localStorage.getItem(LS.password);
         const savedName = localStorage.getItem(LS.name) || "";
         const savedRole = localStorage.getItem(LS.role) || "student";

--- a/src/components/admin/CourseTable.jsx
+++ b/src/components/admin/CourseTable.jsx
@@ -31,7 +31,7 @@ export default function CourseTable({ onCreate }) {
     const [page, setPage] = useState(1);
     const perPage = isMobile ? 6 : 8;
     const pageCount = Math.max(1, Math.ceil(courses.length / perPage));
-    const paginated = useMemo(() => courses.slice((page - 1) * perPage, page * perPage), [courses, page]);
+    const paginated = useMemo(() => courses.slice((page - 1) * perPage, page * perPage), [courses, page, perPage]);
 
     // Edit state
     const [editing, setEditing] = useState(null);

--- a/src/components/admin/MiniArea.jsx
+++ b/src/components/admin/MiniArea.jsx
@@ -2,7 +2,7 @@
 import * as React from "react";
 import { Box, Typography } from "@mui/material";
 
-export default function MiniArea({ data }) {
+export default function MiniArea() {
     return (
         <Box
             sx={{

--- a/src/components/common/navbar.jsx
+++ b/src/components/common/navbar.jsx
@@ -12,6 +12,7 @@ import ShoppingCartIcon from "@mui/icons-material/ShoppingCart";
 import { Link, useNavigate, useLocation } from "react-router-dom";
 import useWishlist from "../../hooks/useWishlist";
 import useCart from "../../hooks/useCart";
+import useEnrollment from "../../hooks/useEnrollment";
 
 import pic1 from "../../assets/images/pic1.jpg";
 import LoginModal from "../Pages/login";
@@ -23,12 +24,17 @@ export default function Navbar() {
     const location = useLocation();
     const { auth, logout } = useAuth();
     const { wishlistItems } = useWishlist();
-    const { cartItems, isProcessing } = useCart();
+    const { cartItems } = useCart();
+    const { enrolledCourses } = useEnrollment();
     const user = auth?.email ? auth : null;
 
     // Ensure arrays are defined
     const safeWishlistItems = wishlistItems || [];
     const safeCartItems = cartItems || [];
+
+    const wishlistCount = safeWishlistItems.filter(
+        (id) => !(enrolledCourses || []).includes(id)
+    ).length;
 
     const [anchorElMobile, setAnchorElMobile] = useState(null);
     const [anchorElUser, setAnchorElUser] = useState(null);
@@ -90,7 +96,7 @@ export default function Navbar() {
                                     sx={{ '&:hover': { color: 'secondary.main' } }}
                                 >
                                     <Badge
-                                        badgeContent={wishlistItems?.length || 0}
+                                        badgeContent={wishlistCount}
                                         color="secondary"
                                         max={99}
                                     >
@@ -109,7 +115,7 @@ export default function Navbar() {
                                     sx={{ '&:hover': { color: 'primary.main' } }}
                                 >
                                     <Badge
-                                        badgeContent={cartItems?.length || 0}
+                                        badgeContent={safeCartItems.length}
                                         color="primary"
                                         max={99}
                                     >

--- a/src/components/course/CourseCard.jsx
+++ b/src/components/course/CourseCard.jsx
@@ -38,15 +38,15 @@ export default function CourseCard({
     const { showNotification } = useNotification();
 
     const inCart = isInCart(id);
-    const inWishlist = isFavorite(id);
+    const favorite = isFavorite(id);
     const enrolled = isEnrolled(id);
 
-    const handleWishlistClick = (e) => {
+    const handleFavoriteClick = (e) => {
         e.preventDefault(); // Prevent card navigation
         e.stopPropagation(); // Stop event bubbling
         toggleFavorite(id);
         showNotification(
-            inWishlist ? 'Removed from wishlist' : 'Added to wishlist',
+            favorite ? 'Removed from favorites' : 'Added to favorites',
             'success'
         );
     };
@@ -117,21 +117,18 @@ export default function CourseCard({
                     </IconButton>
                 </Tooltip>
 
-                {/* Wishlist/Enrolled Icon */}
-                <Tooltip title={enrolled ? "Enrolled" : inWishlist ? "Remove from Wishlist" : "Add to Wishlist"}>
+                {/* Favorites Icon */}
+                <Tooltip title={favorite ? "Remove from Favorites" : "Add to Favorites"}>
                     <IconButton
-                        onClick={handleWishlistClick}
+                        onClick={handleFavoriteClick}
                         sx={{
                             bgcolor: 'rgba(255,255,255,0.9)',
                             '&:hover': {
                                 bgcolor: 'rgba(255,255,255,1)',
                             },
                         }}
-                        disabled={enrolled}
                     >
-                        {enrolled ? (
-                            <SchoolIcon color="primary" />
-                        ) : inWishlist ? (
+                        {favorite ? (
                             <FavoriteIcon color="error" />
                         ) : (
                             <FavoriteBorderIcon />
@@ -191,9 +188,19 @@ export default function CourseCard({
                         mt: 'auto'
                     }}
                 >
-                    <Typography variant="h6" color="primary.main">
-                        ${price}
-                    </Typography>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <Typography variant="h6" color="primary.main">
+                            ${price}
+                        </Typography>
+                        {enrolled && (
+                            <Chip
+                                label="Enrolled"
+                                size="small"
+                                color="success"
+                                sx={{ fontWeight: 'bold' }}
+                            />
+                        )}
+                    </Box>
                     <Typography
                         variant="body2"
                         sx={{

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 // src/contexts/AuthContext.jsx
 import React, { createContext, useCallback, useEffect, useMemo, useState } from "react";
 

--- a/src/contexts/NotificationContext.jsx
+++ b/src/contexts/NotificationContext.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import React, { createContext, useContext, useState } from 'react';
 import { Snackbar, Alert } from '@mui/material';
 

--- a/src/hooks/useFavorites.js
+++ b/src/hooks/useFavorites.js
@@ -1,0 +1,133 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import useAuth from './useAuth';
+import {
+    addToFavorites,
+    removeFromFavorites,
+    setFavorites,
+    selectFavorites
+} from '../redux/slices/favoritesSlice';
+import {
+    addToWishlist,
+    removeFromWishlist,
+    setWishlistItems,
+    selectWishlistItems,
+    selectIsWishlistInitialized
+} from '../redux/slices/wishlistSlice';
+import { selectEnrolledCourses } from '../redux/slices/enrollmentSlice';
+
+export default function useFavorites() {
+    const dispatch = useDispatch();
+    const { auth } = useAuth();
+    const userId = auth?.userId || 'guest';
+
+    const favorites = useSelector(selectFavorites);
+    const wishlistItems = useSelector(selectWishlistItems);
+    const wishlistInitialized = useSelector(selectIsWishlistInitialized);
+    const enrolledCourses = useSelector(selectEnrolledCourses);
+
+    const lastLoadedUserRef = useRef(null);
+
+    useEffect(() => {
+        if (lastLoadedUserRef.current === userId) {
+            return;
+        }
+        lastLoadedUserRef.current = userId;
+
+        try {
+            const savedFavorites = localStorage.getItem(`favorites:${userId}`);
+            const favoritesData = savedFavorites ? JSON.parse(savedFavorites) : [];
+            if (Array.isArray(favoritesData)) {
+                dispatch(setFavorites(favoritesData));
+            } else {
+                throw new Error('Invalid favorites data');
+            }
+        } catch (error) {
+            console.error('Failed to load favorites:', error);
+            dispatch(setFavorites([]));
+        }
+
+        try {
+            const savedWishlist = localStorage.getItem(`wishlist:${userId}`);
+            const wishlistData = savedWishlist ? JSON.parse(savedWishlist) : [];
+            if (Array.isArray(wishlistData)) {
+                dispatch(setWishlistItems(wishlistData));
+            } else {
+                throw new Error('Invalid wishlist data');
+            }
+        } catch (error) {
+            console.error('Failed to load wishlist:', error);
+            dispatch(setWishlistItems([]));
+        }
+    }, [dispatch, userId]);
+
+    const persistFavorites = useCallback((items) => {
+        localStorage.setItem(`favorites:${userId}`, JSON.stringify(items));
+    }, [userId]);
+
+    const persistWishlist = useCallback((items) => {
+        localStorage.setItem(`wishlist:${userId}`, JSON.stringify(items));
+    }, [userId]);
+
+    const isFavorite = useCallback(
+        (courseId) => favorites.includes(courseId),
+        [favorites]
+    );
+
+    const addFavorite = useCallback((courseId) => {
+        if (!courseId || favorites.includes(courseId)) return;
+
+        const updatedFavorites = [...favorites, courseId];
+        dispatch(addToFavorites(courseId));
+        persistFavorites(updatedFavorites);
+
+        if (!enrolledCourses.includes(courseId) && !wishlistItems.includes(courseId)) {
+            const updatedWishlist = [...wishlistItems, courseId];
+            dispatch(addToWishlist(courseId));
+            persistWishlist(updatedWishlist);
+        }
+    }, [dispatch, favorites, enrolledCourses, wishlistItems, persistFavorites, persistWishlist]);
+
+    const removeFavorite = useCallback((courseId) => {
+        if (!courseId || !favorites.includes(courseId)) return;
+
+        const updatedFavorites = favorites.filter(id => id !== courseId);
+        dispatch(removeFromFavorites(courseId));
+        persistFavorites(updatedFavorites);
+
+        if (wishlistItems.includes(courseId)) {
+            const updatedWishlist = wishlistItems.filter(id => id !== courseId);
+            dispatch(removeFromWishlist(courseId));
+            persistWishlist(updatedWishlist);
+        }
+    }, [dispatch, favorites, wishlistItems, persistFavorites, persistWishlist]);
+
+    const toggleFavorite = useCallback((courseId) => {
+        if (!courseId) return;
+        if (isFavorite(courseId)) {
+            removeFavorite(courseId);
+        } else {
+            addFavorite(courseId);
+        }
+    }, [isFavorite, addFavorite, removeFavorite]);
+
+    useEffect(() => {
+        if (!wishlistInitialized) {
+            return;
+        }
+        const filteredWishlist = wishlistItems.filter(id => !enrolledCourses.includes(id));
+        if (filteredWishlist.length !== wishlistItems.length) {
+            dispatch(setWishlistItems(filteredWishlist));
+            persistWishlist(filteredWishlist);
+        }
+    }, [dispatch, enrolledCourses, persistWishlist, wishlistInitialized, wishlistItems]);
+
+    return {
+        favorites,
+        wishlistItems,
+        isFavorite,
+        addFavorite,
+        removeFavorite,
+        toggleFavorite
+    };
+}

--- a/src/hooks/useSearchPagination.js
+++ b/src/hooks/useSearchPagination.js
@@ -14,7 +14,7 @@ export default function useSearchPagination(list, {
         return (list || []).filter(item =>
             keys.some(k => normalize(String(item?.[k] ?? "")).includes(q))
         );
-    }, [list, query]);
+    }, [list, query, keys, normalize]);
 
     const pageCount = Math.max(1, Math.ceil(filtered.length / perPage));
     const paginated = useMemo(

--- a/src/hooks/useWishlist.js
+++ b/src/hooks/useWishlist.js
@@ -12,7 +12,7 @@ export default function useWishlist() {
     const dispatch = useDispatch();
     const { auth } = useAuth();
     const userId = auth?.userId || 'guest';
-    const wishlistItems = useSelector(selectWishlistItems) || [];
+    const wishlistItems = useSelector(selectWishlistItems);
 
     useEffect(() => {
         try {

--- a/src/pages/AdminProfile.jsx
+++ b/src/pages/AdminProfile.jsx
@@ -14,12 +14,10 @@ import {
 } from '@mui/material';
 import useAuth from '../hooks/useAuth';
 import useCourses from '../hooks/useCourses';
-import { useNotification } from '../contexts/NotificationContext';
 
 export default function AdminProfile() {
     const { auth } = useAuth();
     const { courses, seed } = useCourses();
-    const { showNotification } = useNotification();
 
     // Seed courses on component mount
     useEffect(() => {

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -5,12 +5,12 @@ import {
     Card,
     CardContent,
     IconButton,
-    Divider,
     Avatar,
     Container,
     Tab,
     Tabs,
     Grid,
+    Button,
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import useEnrollment from '../hooks/useEnrollment';
@@ -18,6 +18,9 @@ import useCourses from '../hooks/useCourses';
 import useAuth from '../hooks/useAuth';
 import { useNotification } from '../contexts/NotificationContext';
 import ConfirmDialog from '../components/common/ConfirmDialog';
+import useFavorites from '../hooks/useFavorites';
+import useCart from '../hooks/useCart';
+import { Link } from 'react-router-dom';
 
 export default function ProfilePage() {
     const [activeTab, setActiveTab] = React.useState(0);
@@ -25,6 +28,8 @@ export default function ProfilePage() {
     const { enrolledCourses, toggleEnrollment } = useEnrollment();
     const { courses, seed } = useCourses();
     const { showNotification } = useNotification();
+    const { favorites, toggleFavorite } = useFavorites();
+    const { addItemToCart, isInCart } = useCart();
 
     // Seed courses on component mount
     useEffect(() => {
@@ -34,6 +39,13 @@ export default function ProfilePage() {
     const userEnrolledCourses = courses.filter(course =>
         enrolledCourses?.includes(course.id)
     );
+
+    const favoriteCourses = courses.filter(course =>
+        Array.isArray(favorites) && favorites.includes(course.id)
+    );
+
+    const availableFavoriteCourses = favoriteCourses.filter(course => !enrolledCourses.includes(course.id));
+    const enrolledFavoriteCourses = favoriteCourses.filter(course => enrolledCourses.includes(course.id));
 
     const [confirmDialog, setConfirmDialog] = React.useState({
         open: false,
@@ -79,6 +91,7 @@ export default function ProfilePage() {
                 <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
                     <Tabs value={activeTab} onChange={(e, newValue) => setActiveTab(newValue)}>
                         <Tab label="My Courses" />
+                        <Tab label="Favorites" />
                         <Tab label="Settings" />
                     </Tabs>
                 </Box>
@@ -130,6 +143,125 @@ export default function ProfilePage() {
                         </>
                     )}
                     {activeTab === 1 && (
+                        <Box sx={{ py: 4 }}>
+                            <Typography variant="h6" gutterBottom>
+                                Favorites ({favoriteCourses.length})
+                            </Typography>
+
+                            {!favoriteCourses.length && (
+                                <Typography color="text.secondary">
+                                    You haven't added any favorites yet.
+                                </Typography>
+                            )}
+
+                            {!!availableFavoriteCourses.length && (
+                                <Box sx={{ mt: 3 }}>
+                                    <Typography variant="subtitle1" fontWeight="bold" gutterBottom>
+                                        Saved for Later ({availableFavoriteCourses.length})
+                                    </Typography>
+                                    <Grid container spacing={3}>
+                                        {availableFavoriteCourses.map(course => (
+                                            <Grid item xs={12} key={course.id}>
+                                                <Card>
+                                                    <CardContent sx={{ display: 'flex', flexDirection: { xs: 'column', md: 'row' }, gap: 2 }}>
+                                                        <Avatar
+                                                            variant="rounded"
+                                                            src={course.image}
+                                                            sx={{ width: 80, height: 80 }}
+                                                        />
+                                                        <Box sx={{ flexGrow: 1 }}>
+                                                            <Typography variant="h6">
+                                                                {course.title}
+                                                            </Typography>
+                                                            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                                                                {course.description}
+                                                            </Typography>
+                                                            <Typography fontWeight="bold" color="primary.main">
+                                                                ${course.price}
+                                                            </Typography>
+                                                        </Box>
+                                                        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                                                            <Button
+                                                                variant="contained"
+                                                                onClick={() => {
+                                                                    addItemToCart({ courseId: course.id, price: course.price });
+                                                                    showNotification('Course added to cart', 'success');
+                                                                }}
+                                                                disabled={isInCart(course.id)}
+                                                            >
+                                                                {isInCart(course.id) ? 'In Cart' : 'Add to Cart'}
+                                                            </Button>
+                                                            <Button
+                                                                variant="text"
+                                                                color="secondary"
+                                                                onClick={() => {
+                                                                    toggleFavorite(course.id);
+                                                                    showNotification('Removed from favorites', 'info');
+                                                                }}
+                                                            >
+                                                                Remove
+                                                            </Button>
+                                                        </Box>
+                                                    </CardContent>
+                                                </Card>
+                                            </Grid>
+                                        ))}
+                                    </Grid>
+                                </Box>
+                            )}
+
+                            {!!enrolledFavoriteCourses.length && (
+                                <Box sx={{ mt: 4 }}>
+                                    <Typography variant="subtitle1" fontWeight="bold" gutterBottom>
+                                        Enrolled Favorites ({enrolledFavoriteCourses.length})
+                                    </Typography>
+                                    <Grid container spacing={3}>
+                                        {enrolledFavoriteCourses.map(course => (
+                                            <Grid item xs={12} key={course.id}>
+                                                <Card>
+                                                    <CardContent sx={{ display: 'flex', flexDirection: { xs: 'column', md: 'row' }, gap: 2 }}>
+                                                        <Avatar
+                                                            variant="rounded"
+                                                            src={course.image}
+                                                            sx={{ width: 80, height: 80 }}
+                                                        />
+                                                        <Box sx={{ flexGrow: 1 }}>
+                                                            <Typography variant="h6">
+                                                                {course.title}
+                                                            </Typography>
+                                                            <Typography variant="body2" color="text.secondary">
+                                                                {course.description}
+                                                            </Typography>
+                                                        </Box>
+                                                        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                                                            <Button
+                                                                variant="outlined"
+                                                                component={Link}
+                                                                to={`/courses/${course.id}`}
+                                                            >
+                                                                View Course
+                                                            </Button>
+                                                            <Button
+                                                                variant="text"
+                                                                color="secondary"
+                                                                onClick={() => {
+                                                                    toggleFavorite(course.id);
+                                                                    showNotification('Removed from favorites', 'info');
+                                                                }}
+                                                            >
+                                                                Remove
+                                                            </Button>
+                                                        </Box>
+                                                    </CardContent>
+                                                </Card>
+                                            </Grid>
+                                        ))}
+                                    </Grid>
+                                </Box>
+                            )}
+                        </Box>
+                    )}
+                    {activeTab === 2 && (
                         <Box sx={{ py: 4 }}>
                             <Typography variant="h6" gutterBottom>
                                 Account Settings

--- a/src/pages/TeacherDetail.jsx
+++ b/src/pages/TeacherDetail.jsx
@@ -48,6 +48,16 @@ export default function TeacherDetail() {
     [teachers, id]
   );
 
+  const teacherId = teacher?.id;
+
+  const allCourses = useMemo(
+    () =>
+      teacherId ? courses.filter((c) => String(c.teacherId) === String(teacherId)) : [],
+    [courses, teacherId]
+  );
+
+  const [page, setPage] = useState(1);
+
   if (!teacher) {
     return (
       <Box sx={{ p: 4, textAlign: "center" }}>
@@ -56,19 +66,12 @@ export default function TeacherDetail() {
     );
   }
 
-  const allCourses = useMemo(
-    () => courses.filter((c) => String(c.teacherId) === String(teacher.id)),
-    [courses, teacher.id]
-  );
-
   const languages = Array.isArray(teacher.languages) && teacher.languages.length
     ? teacher.languages
     : ["Arabic", "English"];
   const aboutText = teacher.about || teacher.description || teacher.bio || "No bio.";
   const certText = teacher.certification || teacher.cert || "No certification info.";
   const rating = Math.max(0, Math.min(5, Number(teacher.rating || 0)));
-
-  const [page, setPage] = useState(1);
   const perPage = 4;
   const pageCount = Math.max(1, Math.ceil(allCourses.length / perPage));
   const paginated = allCourses.slice((page - 1) * perPage, page * perPage);

--- a/src/pages/Wishlist.jsx
+++ b/src/pages/Wishlist.jsx
@@ -11,13 +11,15 @@ import { Link, useNavigate } from 'react-router-dom';
 import useWishlist from '../hooks/useWishlist';
 import useCourses from '../hooks/useCourses';
 import useCart from '../hooks/useCart';
+import useEnrollment from '../hooks/useEnrollment';
 import CourseCard from '../components/course/CourseCard';
 import { useNotification } from '../contexts/NotificationContext';
 
 export default function WishlistPage() {
     const navigate = useNavigate();
-    const { wishlistItems, isInWishlist, toggleWishlist } = useWishlist();
+    const { wishlistItems } = useWishlist();
     const { courses, isLoading: coursesLoading, seed } = useCourses();
+    const { enrolledCourses } = useEnrollment();
 
     // Seed courses on component mount
     useEffect(() => {
@@ -26,13 +28,19 @@ export default function WishlistPage() {
     const { addItemToCart } = useCart();
     const { showNotification } = useNotification();
 
-    // Get full course objects for items in wishlist
+    // Get full course objects for items in wishlist that are not yet enrolled
     const wishlistCourses = courses.filter(course =>
-        Array.isArray(wishlistItems) && wishlistItems.includes(course.id)
+        Array.isArray(wishlistItems) &&
+        wishlistItems.includes(course.id) &&
+        !enrolledCourses.includes(course.id)
     );
 
+    const enrolledWishlistCount = Array.isArray(wishlistItems)
+        ? wishlistItems.filter(id => enrolledCourses.includes(id)).length
+        : 0;
+
     // Add state debugger
-    const showDebug = process.env.NODE_ENV === 'development';
+    const showDebug = import.meta.env.MODE === 'development';
 
     if (coursesLoading) {
         return showDebug ? <StateDebugger /> : (
@@ -96,6 +104,13 @@ export default function WishlistPage() {
                 >
                     My Wishlist ({wishlistCourses.length})
                 </Typography>
+
+                {enrolledWishlistCount > 0 && (
+                    <Typography color="text.secondary" sx={{ mb: 3 }}>
+                        {enrolledWishlistCount} {enrolledWishlistCount === 1 ? 'course has' : 'courses have'}
+                        {' '}been moved to your favorites because you are already enrolled.
+                    </Typography>
+                )}
 
                 <Grid container spacing={3}>
                     {wishlistCourses.map(course => (

--- a/src/redux/slices/favoritesSlice.js
+++ b/src/redux/slices/favoritesSlice.js
@@ -1,53 +1,29 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, createSelector } from '@reduxjs/toolkit';
 
-const loadInitialState = () => {
-    try {
-        const savedState = localStorage.getItem('favorites');
-        return savedState ? {
-            items: JSON.parse(savedState),
-            loading: false,
-            error: null
-        } : {
-            items: [],
-            loading: false,
-            error: null
-        };
-    } catch (e) {
-        console.error('Failed to load favorites:', e);
-        return {
-            items: [],
-            loading: false,
-            error: null
-        };
-    }
+const initialState = {
+    items: [],
+    initialized: false
 };
-
-const initialState = loadInitialState();
 
 const favoritesSlice = createSlice({
     name: 'favorites',
     initialState,
     reducers: {
         addToFavorites: (state, action) => {
-            if (!state.items.includes(action.payload)) {
-                state.items.push(action.payload);
-                // Save to localStorage
-                localStorage.setItem('favorites', JSON.stringify(state.items));
+            const courseId = action.payload;
+            if (!state.items.includes(courseId)) {
+                state.items.push(courseId);
             }
         },
         removeFromFavorites: (state, action) => {
             state.items = state.items.filter(id => id !== action.payload);
-            localStorage.setItem('favorites', JSON.stringify(state.items));
         },
         setFavorites: (state, action) => {
-            state.items = action.payload;
-            localStorage.setItem('favorites', JSON.stringify(action.payload));
+            state.items = action.payload || [];
+            state.initialized = true;
         },
-        initializeFavorites: (state) => {
-            const savedFavorites = localStorage.getItem('favorites');
-            if (savedFavorites) {
-                state.items = JSON.parse(savedFavorites);
-            }
+        clearFavorites: (state) => {
+            state.items = [];
         }
     }
 });
@@ -56,11 +32,24 @@ export const {
     addToFavorites,
     removeFromFavorites,
     setFavorites,
-    initializeFavorites
+    clearFavorites
 } = favoritesSlice.actions;
 
-// Selectors
-export const selectFavorites = state => state.favorites.items;
-export const selectIsFavorite = (state, courseId) => state.favorites.items.includes(courseId);
+const getFavoritesState = state => state?.favorites || initialState;
+
+export const selectFavorites = createSelector(
+    [getFavoritesState],
+    state => state?.items || []
+);
+
+export const selectIsFavorite = courseId => createSelector(
+    [selectFavorites],
+    items => items.includes(courseId)
+);
+
+export const selectAreFavoritesInitialized = createSelector(
+    [getFavoritesState],
+    state => Boolean(state?.initialized)
+);
 
 export default favoritesSlice.reducer;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -33,7 +33,9 @@ function saveState(state) {
             enrollment: state.enrollment,
         };
         localStorage.setItem(PERSIST_KEY, JSON.stringify(toSave));
-    } catch { }
+    } catch (error) {
+        console.error('Failed to save state:', error);
+    }
 }
 
 const store = configureStore({


### PR DESCRIPTION
## Summary
- add a dedicated favorites hook and update cards, navbar, and store slices so favorites persist per user while the wishlist only reflects not-enrolled courses
- clear local storage on checkout, add a favorites tab in the profile, and filter wishlist items based on enrollment to keep flows consistent
- address related lint warnings across the app and fix miscellaneous pre-existing issues uncovered by linting
 